### PR TITLE
🐛 Fix nconfetti-assigning

### DIFF
--- a/src/app_bootstrapper.ts
+++ b/src/app_bootstrapper.ts
@@ -42,7 +42,13 @@ export class AppBootstrapper {
 
   private initializeConfigProvider(): void {
 
-    require('nconfetti'); // tslint:disable-line
+    // nconfetti tries to register itself to nconf
+    // (here: https://github.com/5minds/nconfetti/blob/f9eae47cd3a194136b6b06328efcf6f39836c9d3/lib/nconfetti.js#L134)
+    // for this to work however, the nconf-instance in nconfetti has to be the
+    // same instance we have here in this file. This on the other hand seems to
+    // not always be the case. We can still make it work, by manually
+    // registering nconfetti to our nconf-instance we have here.
+    nconf.Nconfetti = require('nconfetti'); // tslint:disable-line
 
     nconf.argv()
       .env('__');


### PR DESCRIPTION
## What did you change?

I registered nconfetti to nconf by hand, so we don't rely on nconfetti doing that implicitly. This fixes an error that occured, when the nconf-instance within nconfetti was not the same as the one in the app-bootstrapper.

## How can others test the changes?

Everything should work just as it did before, but the following error should no longer happen:
```
Error: Cannot add store with unknown type: Nconfetti
```

## PR-Checklist

Please check the boxes in this list after submitting your PR:

- [x] You can merge this PR **right now** (if not, please prefix the title with "WIP: ")
- [x] I've tested **all** changes included in this PR.
- [x] I've also reviewed this PR myself before submitting (e.g. for scrambled letters, typos, etc.)
- [x] I've merged the `develop` branch into my branch before finishing this PR.
- [x] I've **not added any other changes** than the ones described above.
- [x] I've mentioned all **PRs, which relate to this one**
